### PR TITLE
avoid heap allocation of local parameters in callHost, possible performance improvement

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1546,8 +1546,18 @@ Result Thread::CallHost(HostFunc* func) {
 
   size_t num_params = sig->param_types.size();
   size_t num_results = sig->result_types.size();
-  TypedValues params(num_params);
-  TypedValues results(num_results);
+
+  static thread_local TypedValues params(num_params);
+  static thread_local TypedValues results(num_results);
+  static thread_local bool _init = false;
+  if (!_init) {
+    params.reserve(32);
+    results.reserve(32);
+    _init = true;
+  }
+
+  params.resize(num_params);
+  results.resize(num_results);
 
   for (size_t i = num_params; i > 0; --i) {
     params[i - 1].value = Pop();

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1547,8 +1547,8 @@ Result Thread::CallHost(HostFunc* func) {
   size_t num_params = sig->param_types.size();
   size_t num_results = sig->result_types.size();
 
-  static thread_local TypedValues params(num_params);
-  static thread_local TypedValues results(num_results);
+  static thread_local TypedValues params;
+  static thread_local TypedValues results;
   static thread_local bool _init = false;
   if (!_init) {
     params.reserve(32);


### PR DESCRIPTION
use ```static thread_local``` for local variables ```params``` and ```results``` to avoid frequent heap allocations. Note: this doesn't not work if callHost is invoked recursively.