### PR TITLE
Changes to StringPrintf

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -140,6 +140,10 @@ void Destruct(T& placement) {
   placement.~T();
 }
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+
 inline std::string WABT_PRINTF_FORMAT(1, 2)
     StringPrintf(const char* format, ...) {
   va_list args;
@@ -155,6 +159,8 @@ inline std::string WABT_PRINTF_FORMAT(1, 2)
   va_end(args_copy);
   return std::string(buffer.data(), len - 1);
 }
+
+#pragma GCC diagnostic pop
 
 enum class LabelType {
   Func,

--- a/src/common.h
+++ b/src/common.h
@@ -141,7 +141,7 @@ void Destruct(T& placement) {
 }
 
 
-if __GNUC__ >= 7
+#if __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
@@ -162,7 +162,7 @@ inline std::string WABT_PRINTF_FORMAT(1, 2)
   return std::string(buffer.data(), len - 1);
 }
 
-if __GNUC__ >= 7
+#if __GNUC__ >= 7
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/common.h
+++ b/src/common.h
@@ -146,7 +146,9 @@ inline std::string WABT_PRINTF_FORMAT(1, 2)
   va_list args_copy;
   va_start(args, format);
   va_copy(args_copy, args);
-  size_t len = wabt_vsnprintf(nullptr, 0, format, args) + 1;  // For \0.
+  int res = wabt_vsnprintf(nullptr, 0, format, args);
+  if( res <= 0 ) return {}; // return empty string on error or if the format string is empty
+  size_t len =  res + 1;  // For \0.
   std::vector<char> buffer(len);
   va_end(args);
   wabt_vsnprintf(buffer.data(), len, format, args_copy);

--- a/src/common.h
+++ b/src/common.h
@@ -141,8 +141,10 @@ void Destruct(T& placement) {
 }
 
 
+if __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 
 inline std::string WABT_PRINTF_FORMAT(1, 2)
     StringPrintf(const char* format, ...) {
@@ -160,7 +162,9 @@ inline std::string WABT_PRINTF_FORMAT(1, 2)
   return std::string(buffer.data(), len - 1);
 }
 
+if __GNUC__ >= 7
 #pragma GCC diagnostic pop
+#endif
 
 enum class LabelType {
   Func,


### PR DESCRIPTION
This PR modifies the `StringPrintf` function to handle the case in which `vsnprintf` returns a negative value to indicate an error occurred. In this case, and also in the case where the format string is empty, it will now return the empty string.

Furthermore, pragmas are used to not treat the `format-truncation` warning as an error. This only applies to GCC 7+. These pragmas are needed because otherwise the second usage of `vsnprintf` in this function will cause a `null destination pointer [-Werror=format-truncation=]` compilation error when compiling with a GCC 7 compiler on CentOS 7.